### PR TITLE
Make raising an error optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ SanePatch::Errors::IncompatibleVersion:
   Make sure that the patch at initializers/greeter_patch.rb:8 is still needed and working.
 ```
 
+Setting the `raise_error` keyword argument to `true` will skip the execution of the block but will not raise an error.
+
 ### Complex version constraints
 
 SanePatch supports all [version constraints](http://docs.seattlerb.org/rubygems/Gem/Requirement.html) you know and love from RubyGems.
@@ -121,6 +123,14 @@ SanePatch::Errors::IncompatibleVersion:
   The `silence` method should output an empty string rather than nil.
   This is a known issue and will be fixed in the next release.
   See: https://github.com/Jcambass/greeter/issues/45
+```
+
+### Logging support
+
+The `logger` keyword argument can be used to supply a logger instance.  SanePatch will pass the exception message to that object's `#warn` method when the version constraint is not satisfied:
+
+```ruby
+SanePatch.patch('greeter', '1.1.0', logger: Logger.new(STDOUT)) { # your patch }
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ SanePatch::Errors::IncompatibleVersion:
   Make sure that the patch at initializers/greeter_patch.rb:8 is still needed and working.
 ```
 
-Setting the `raise_error` keyword argument to `true` will skip the execution of the block but will not raise an error.
+Setting the `raise_error` keyword argument to `false` will skip the execution of the block but will not raise an error.  (The default value for the keyword is `true`.)
 
 ### Complex version constraints
 

--- a/lib/sane_patch.rb
+++ b/lib/sane_patch.rb
@@ -6,7 +6,7 @@ module SanePatch
     IncompatibleVersion = Class.new(RuntimeError)
   end
 
-  def self.patch(gem_name, *requirements, details: nil)
+  def self.patch(gem_name, *requirements, details: nil, raise_error: true)
     gem_spec = Gem.loaded_specs[gem_name]
     raise Errors::GemAbsent, "Can't patch unloaded gem #{gem_name}" unless gem_spec
 
@@ -21,7 +21,7 @@ module SanePatch
       ERROR
       message += "Details:\n#{details}" if details
 
-      raise Errors::IncompatibleVersion, message
+      raise Errors::IncompatibleVersion, message if raise_error
     end
   end
 end

--- a/lib/sane_patch.rb
+++ b/lib/sane_patch.rb
@@ -6,7 +6,7 @@ module SanePatch
     IncompatibleVersion = Class.new(RuntimeError)
   end
 
-  def self.patch(gem_name, *requirements, details: nil, raise_error: true)
+  def self.patch(gem_name, *requirements, details: nil, raise_error: true, logger: nil)
     gem_spec = Gem.loaded_specs[gem_name]
     raise Errors::GemAbsent, "Can't patch unloaded gem #{gem_name}" unless gem_spec
 
@@ -20,6 +20,8 @@ module SanePatch
         Make sure that the patch at #{caller_locations.first} is still needed and working.
       ERROR
       message += "Details:\n#{details}" if details
+
+      logger.warn(message) if logger
 
       raise Errors::IncompatibleVersion, message if raise_error
     end

--- a/spec/sane_patch_spec.rb
+++ b/spec/sane_patch_spec.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 RSpec.describe SanePatch do
   it "has a version number" do
     expect(SanePatch::VERSION).not_to be nil
@@ -47,6 +49,31 @@ RSpec.describe SanePatch do
         it "doesn't raise an error for incompatible version constraints" do
           with_loaded_gems('some_gem' => "1.0.1") do
             expect { |b| SanePatch.patch('some_gem', ">= 0.0.1", "< 1.0.0", raise_error: false, &b) }.to engage_guard_no_raise
+          end
+        end
+      end
+
+      context "when configured with a logger" do
+        let(:logger) { instance_double(Logger) }
+
+        it "logs a warning for incompatible version" do
+          with_loaded_gems('some_gem' => "1.0.1") do
+            expect(logger).to receive(:warn).with(/some_gem/)
+            SanePatch.patch('some_gem', "0.0.1", logger: logger, raise_error: false) { raise "Won't execute" }
+          end
+        end
+
+        it "logs a warning for incompatible version constraint" do
+          with_loaded_gems('some_gem' => "1.0.1") do
+            expect(logger).to receive(:warn).with(/some_gem/)
+            SanePatch.patch('some_gem', "0.0.1", logger: logger, raise_error: false) { raise "Won't execute" }
+          end
+        end
+
+        it "logs a warning for incompatible version constraints" do
+          with_loaded_gems('some_gem' => "1.0.1") do
+            expect(logger).to receive(:warn).with(/some_gem/)
+            SanePatch.patch('some_gem', "0.0.1", logger: logger, raise_error: false) { raise "Won't execute" }
           end
         end
       end

--- a/spec/sane_patch_spec.rb
+++ b/spec/sane_patch_spec.rb
@@ -31,6 +31,26 @@ RSpec.describe SanePatch do
         end
       end
 
+      context "when configured to not raise an error" do
+        it "doesn't raise an error for incompatible version" do
+          with_loaded_gems('some_gem' => "1.0.1") do
+            expect { |b| SanePatch.patch('some_gem', "0.0.1", raise_error: false, &b) }.to engage_guard_no_raise
+          end
+        end
+
+        it "doesn't raise an error for incompatible version constraint" do
+          with_loaded_gems('some_gem' => "1.0.1") do
+            expect { |b| SanePatch.patch('some_gem', "~> 0.0.1", raise_error: false, &b) }.to engage_guard_no_raise
+          end
+        end
+
+        it "doesn't raise an error for incompatible version constraints" do
+          with_loaded_gems('some_gem' => "1.0.1") do
+            expect { |b| SanePatch.patch('some_gem', ">= 0.0.1", "< 1.0.0", raise_error: false, &b) }.to engage_guard_no_raise
+          end
+        end
+      end
+
       it "execute block for compatible version" do
         with_loaded_gems('some_gem' => "1.0.1") do
           expect { |b| SanePatch.patch('some_gem', "1.0.1", &b) }.not_to engage_guard

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,3 +42,15 @@ RSpec::Matchers.define :engage_guard do
 
   supports_block_expectations
 end
+
+RSpec::Matchers.define :engage_guard_no_raise do
+  match do |actual|
+    yielded = false
+    expect {
+      actual.call(Proc.new { yielded = true })
+     }.to_not raise_error
+    expect(yielded).to be_falsey
+  end
+
+  supports_block_expectations
+end


### PR DESCRIPTION
It would be helpful to have `SanePatch` optionally not apply a monkey patch but also not raise an error.  For example, upgrading Rails can be a long running effort and I try to run a parallel build in CI to avoid regressions.  In that situation, I would like for `SanePatch` to not apply monkey patches for bugs that have been fixed in the new version of Rails but not raise an error so that the test suite will run.

To address concerns that patches will accumulate and never be cleaned up, this PR also adds the ability to pass in a `Logger` instance and will emit `warn` messages whenever a patch is skipped.